### PR TITLE
Enhancement - Close Sidebar by Clicking Outside

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -72,6 +72,7 @@ window.$zopim||(function(d,s){var z=$zopim=function(c){z._.push(c)},$=z.s=
           </ul>
         </aside>
         <div ng-view autoscroll></div>
+        <a class="exit-off-canvas"></a>
       </div>
     </div>
 


### PR DESCRIPTION
With this addition, you can close the sidebar by clicking the body of the page. Makes it a lot easier to close the sidebar on mobile devices. As most websites do this, we would conform to common standards.

Info for this change was pulled straight from the Foundation documentation.
